### PR TITLE
2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changes to cssdb
 
+### 2.0.0 (April 7th, 2018)
+
+- Renamed: GitHub repository from `css-db` to `cssdb`, now aligning with npm.
+- Renamed: All feature IDs.
+- Updated: Documentation.
+
+Notes: The old feature IDs were problematic because they attempted to follow
+specification section IDs, but some specifications weren’t aren’t always
+covered by a single section, and many sections were inconsistently named.
+Because there was no pattern one could predict for any of the headings, a new
+system was created; to **name** the feature and provide **context**. This meant
+a feature ID like `css-cascade-all-shorthand` became `all-property`, and `css-fonts-propdef-font-variant` became `font-variant-property`, etc. This
+greatly simplified all of the feature IDs and allowed for more predictive
+naming moving forward.
+
 ### 1.6.0 (February 18th, 2018)
 
 - Added: Break Properties

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,8 +3,8 @@
 Pull requests are the most helpful contributions.
 
 I love folks who can add missing features and keep existing features up to date.
-A new feature only needs a **title**, a **description**, and a link to its
-**specification**.
+A new feature only needs a **title**, **id**, **description**, and a link to
+its **specification**.
 
 Non-CSSWG members can still update CSS features by including **citations** to
 public notes that show how the CSSWG is advancing a feature. If you need
@@ -30,16 +30,16 @@ you’re unfamiliar with git, consider the following workflow.
 1. To begin; [fork this project] and then clone your fork locally
    ```bash
    # Clone your fork of this project
-   git clone git@github.com:YOUR_USER/css-db.git
+   git clone git@github.com:YOUR_USER/cssdb.git
 
    # Navigate to your fork of this project
-   cd css-db
+   cd cssdb
 
    # Install the tools necessary for testing this project
    npm install
 
    # Assign the original repo to a remote called "upstream"
-   git remote add upstream git@github.com:jonathantneal/css-db.git
+   git remote add upstream git@github.com:jonathantneal/cssdb.git
    ```
 
 2. Create a branch for your feature or fix:
@@ -72,23 +72,21 @@ you’re unfamiliar with git, consider the following workflow.
 
 The only fields you’ll see in [`cssdb.json`] are, in order:
 
+- `id`: the feature shortname, similar to a specification [Shortname].
 - `title`: the name of the feature.
 - `description`: a brief description of the feature.
-- `specification`: a link to feature’s specification.
-- `specificationId`: the specification’s [Shortname]
-   (and [Section Heading ID], if necessary).
-- `stage`: the position of the feature within the [staging process]. Stages
-   should be a number, and no stage (*unrecognized*) should be `null`.
+- `specification`: a link to the specification for the feature.
 - `stage`: the current [stage](README.md#staging-process) of the feature; where
     + `0` means **Stage 0** — *Aspirational*,
-    + `1` means **Stage 1** — *Experimental*,
-    + `2` means **Stage 2** — *Draft*,
-    + `3` means **Stage 3** — *Adoption*,
-    + `4` means **Stage 4** — *Complete*, and
+    + `1` means **Stage 1** — *Enthusiastic*,
+    + `2` means **Stage 2** — *Experimental*,
+    + `3` means **Stage 3** — *Allowable*,
+    + `4` means **Stage 4** — *Embraced*,
+    + `5` means **Stage 5** — *Standardized*, and
     + `-1` means **Rejected**.
-- `polyfills`: A list of polyfills used to simulate the feature; which includes
+- `polyfills`: a list of polyfills used to simulate the feature; each including
     + `type`: the type of polyfill (e.g. *PostCSS*, *JS Library*), and
-    + `link`: the URL to the page or repository for the polyfill.
+    + `link`: the URL to the repository for the polyfill.
 
 All contributions must follow the existing syntax and style of the JSON file,
 which;

--- a/README.md
+++ b/README.md
@@ -1,24 +1,35 @@
-# cssdb [<img src="https://jonathantneal.github.io/css-db/cssdb.svg" alt="cssdb logo" width="90" height="90" align="right">][cssdb]
+# cssdb [<img src="https://jonathantneal.github.io/cssdb/cssdb.svg" alt="cssdb logo" width="90" height="90" align="right">][cssdb]
 
 [![NPM Version][npm-img]][npm-url]
 [![Build Status][cli-img]][cli-url]
-[![Licensing][lic-img]][lic-url]
 
 [cssdb] is a comprehensive list of CSS features and their positions in
 the process of becoming implemented web standards.
+
+---
 
 Did you come here to update the status of a CSS feature or add a new one?
 Quick, read [CONTRIBUTING.md](CONTRIBUTING.md).
 
 Did you come here to learn about the stages? Quick, read [STAGES.md](STAGES.md).
 
-[cssdb]: https://github.com/jonathantneal/css-db
+---
 
-[npm-url]: https://www.npmjs.com/package/cssdb
+[cssdb] ranks CSS features by stages that reflect the real-life stability of
+new CSS features.
+
+You can read an [inside view of the CSSWG] to learn about the official
+(and unofficial) development stages of CSS specifications. In reality,
+specifications and browser implementations happen out of sync. For example,
+there are stable CSS features missing in all browsers, while other CSS features
+developed outside the [CSSWG] have appeared in browsers behind flags. This is
+too ambiguous for the web development community, and a more accountable process
+is desired.
+
+[cli-img]: https://img.shields.io/travis/jonathantneal/cssdb.svg
+[cli-url]: https://travis-ci.org/jonathantneal/cssdb
+[cssdb]: https://github.com/jonathantneal/cssdb
+[CSSWG]: https://wiki.csswg.org/spec
+[inside view of the CSSWG]: http://fantasai.inkedblade.net/weblog/2011/inside-csswg/process
 [npm-img]: https://img.shields.io/npm/v/cssdb.svg
-[cli-url]: https://travis-ci.org/jonathantneal/css-db
-[cli-img]: https://img.shields.io/travis/jonathantneal/css-db.svg
-[lic-url]: LICENSE.md
-[lic-img]: https://img.shields.io/badge/license-CC0--1.0-blue.svg
-[git-url]: https://gitter.im/postcss/postcss
-[git-img]: https://img.shields.io/badge/chat-gitter-blue.svg
+[npm-url]: https://www.npmjs.com/package/cssdb

--- a/STAGES.md
+++ b/STAGES.md
@@ -1,4 +1,4 @@
-## Staging Process
+## The Staging Process
 
 Staging processes allow developers to accomplish real things and get involved
 in the creation of standards, testing, feedback, and new use cases.
@@ -15,7 +15,7 @@ is desired.
 
 ### Stage 0: Aspirational
 
-<img src="https://jonathantneal.github.io/css-db/stage-0.svg" align="left" width="90" height="90">
+<img src="https://jonathantneal.github.io/cssdb/stage-0.svg" align="left" width="90" height="90">
 
 > “This is my crazy idea.”
 
@@ -26,7 +26,7 @@ considered highly unstable and subject to change.
 
 ### Stage 1: Enthusiastic
 
-<img src="https://jonathantneal.github.io/css-db/stage-1.svg" align="left" width="90" height="90">
+<img src="https://jonathantneal.github.io/cssdb/stage-1.svg" align="left" width="90" height="90">
 
 > “This is a crazy idea.”
 
@@ -37,7 +37,7 @@ considered highly unstable and subject to change.
 
 ### Stage 2: Experimental
 
-<img src="https://jonathantneal.github.io/css-db/stage-2.svg" align="left" width="90" height="90">
+<img src="https://jonathantneal.github.io/cssdb/stage-2.svg" align="left" width="90" height="90">
 
 > “This idea might not be crazy.”
 
@@ -48,7 +48,7 @@ considered highly unstable and subject to change.
 
 ### Stage 3: Allowable
 
-<img src="https://jonathantneal.github.io/css-db/stage-3.svg" align="left" width="90" height="90">
+<img src="https://jonathantneal.github.io/cssdb/stage-3.svg" align="left" width="90" height="90">
 
 > “This idea is not crazy.”
 
@@ -60,7 +60,7 @@ little change. It is still subject to rejection as a standard.
 
 ### Stage 4: Embraced
 
-<img src="https://jonathantneal.github.io/css-db/stage-4.svg" align="left" width="90" height="90">
+<img src="https://jonathantneal.github.io/cssdb/stage-4.svg" align="left" width="90" height="90">
 
 > “This idea is becoming part of the web.”
 
@@ -73,7 +73,7 @@ become a standard.
 
 ### Stage 5: Standardized
 
-<img src="https://jonathantneal.github.io/css-db/stage-5.svg" align="left" width="90" height="90">
+<img src="https://jonathantneal.github.io/cssdb/stage-5.svg" align="left" width="90" height="90">
 
 > “This idea is part of the web.”
 
@@ -84,7 +84,7 @@ A **Recommendation** [hosted] by the [CSSWG] or [W3C] and implemented by all
 
 ### Rejected
 
-<img src="https://jonathantneal.github.io/css-db/stage-X.svg" align="left" width="90" height="90">
+<img src="https://jonathantneal.github.io/cssdb/stage-X.svg" align="left" width="90" height="90">
 
 > “I had no idea what I was doing.”
 

--- a/cssdb.json
+++ b/cssdb.json
@@ -1,24 +1,9 @@
 [
   {
-    "title": "Break Properties",
-    "description": "Properties for defining the break behavior between and within boxes",
-    "specification": "https://www.w3.org/TR/css-break-3/#breaking-controls",
-    "specificationId": "break-properties",
-    "stage": 4,
-    "caniuse": "multicolumn",
-    "example": "a {\n  break-inside: avoid;\n  break-before: avoid-column;\n  break-after: always;\n}",
-    "polyfills": [
-      {
-        "type": "PostCSS Plugin",
-        "link": "https://github.com/shrpne/postcss-page-break"
-      }
-    ]
-  },
-  {
-    "title": "Cascade `all` Property",
+    "id": "all-property",
+    "title": "`all` Property",
     "description": "A property for defining the reset of all properties of an element",
     "specification": "https://www.w3.org/TR/css-cascade-3/#all-shorthand",
-    "specificationId": "css-cascade-all-shorthand",
     "stage": 4,
     "caniuse": "css-all",
     "example": "a {\n  all: initial;\n}",
@@ -30,294 +15,10 @@
     ]
   },
   {
-    "title": "Color Functional Notation",
-    "description": "A space and slash separated notation specifying colors",
-    "specification": "https://drafts.csswg.org/css-color/#ref-for-funcdef-rgb%E2%91%A1%E2%91%A0",
-    "specificationId": "css-color-functional-notation",
-    "stage": 2,
-    "example": "em {\n  background-color: hsl(120deg 100% 25%);\n  box-shadow: 0 0 0 10px hwb(120deg 100% 25% / 80%);\n  color: rgb(0 255 0);\n}"
-  },
-  {
-    "title": "Color `#RRGGBBAA` Notation",
-    "description": "A 4 & 8 character hex notation for color to include the opacity level",
-    "specification": "https://www.w3.org/TR/css-color-4/#hex-notation",
-    "specificationId": "css-color-hex-notation",
-    "stage": 3,
-    "caniuse": "css-rrggbbaa",
-    "example": "section {\n  background-color: #f3f3f3f3;\n  color: #0003;\n}",
-    "polyfills": [
-      {
-        "type": "PostCSS Plugin",
-        "link": "https://github.com/postcss/postcss-color-hex-alpha"
-      }
-    ]
-  },
-  {
-    "title": "Color `color-mod()` Function",
-    "description": "A function used to modify a color",
-    "specification": "https://www.w3.org/TR/css-color-4/#modifying-colors",
-    "specificationId": "css-color-modifying-colors",
-    "stage": 3,
-    "example": "p {\n  color: color-mod(black alpha(50%));\n}",
-    "polyfills": [
-      {
-        "type": "PostCSS Plugin",
-        "link": "https://github.com/jonathantneal/postcss-color-mod-function"
-      }
-    ]
-  },
-  {
-    "title": "Color `gray()` Function",
-    "description": "A function used to create fully desaturated colors",
-    "specification": "https://www.w3.org/TR/css-color-4/#grays",
-    "specificationId": "css-color-grays",
-    "stage": 3,
-    "example": "p {\n  color: gray(red);\n}",
-    "polyfills": [
-      {
-        "type": "PostCSS Plugin",
-        "link": "https://github.com/postcss/postcss-color-gray"
-      }
-    ]
-  },
-  {
-    "title": "Color `hwb()` Function",
-    "description": "A function used to specify colors, similar to HSL, but often even easier for humans to work with",
-    "specification": "https://www.w3.org/TR/css-color-4/#the-hwb-notation",
-    "specificationId": "css-color-hwb-notation",
-    "stage": 3,
-    "example": "p {\n  color: hwb(120, 44%, 50%);\n}",
-    "polyfills": [
-      {
-        "type": "PostCSS Plugin",
-        "link": "https://github.com/postcss/postcss-color-hwb"
-      }
-    ]
-  },
-  {
-    "title": "Color `rebeccapurple`",
-    "description": "A particularly lovely shade of purple in memory of Rebecca Alison Meyer",
-    "specification": "https://www.w3.org/TR/css-color-4/#valdef-color-rebeccapurple",
-    "specificationId": "css-color-valdef-color-rebeccapurple",
-    "stage": 3,
-    "caniuse": "css-rebeccapurple",
-    "example": "html {\n  color: rebeccapurple;\n}",
-    "polyfills": [
-      {
-        "type": "PostCSS Plugin",
-        "link": "https://github.com/postcss/postcss-color-rebeccapurple"
-      }
-    ]
-  },
-  {
-    "title": "Custom Properties",
-    "description": "A syntax for defining custom values accepted by all CSS properties",
-    "specification": "https://www.w3.org/TR/css-variables-1/",
-    "specificationId": "css-variables",
-    "stage": 4,
-    "caniuse": "css-variables",
-    "example": "img {\n  --some-length: 32px;\n\n  height: var(--some-length);\n  width: var(--some-length);\n}",
-    "polyfills": [
-      {
-        "type": "PostCSS Plugin",
-        "link": "https://github.com/postcss/postcss-custom-properties"
-      }
-    ]
-  },
-  {
-    "title": "Custom Property Sets",
-    "description": "A syntax for storing properties in a named variable, referenceable in other style rules",
-    "specification": "https://tabatkins.github.io/specs/css-apply-rule/",
-    "specificationId": "css-apply-rule",
-    "stage": -1,
-    "caniuse": "css-apply-rule",
-    "example": "img {\n  --some-length-styles: {\n    height: 32px;\n    width: 32px;\n  };\n\n  @apply --some-length-styles;\n}",
-    "polyfills": [
-      {
-        "type": "PostCSS Plugin",
-        "link": "https://github.com/pascalduez/postcss-apply"
-      }
-    ]
-  },
-  {
-    "title": "Custom Selectors",
-    "description": "An at-rule defining aliases representing selectors",
-    "specification": "https://drafts.csswg.org/css-extensions/#custom-selectors",
-    "specificationId": "css-extensions-custom-selectors",
-    "stage": 2,
-    "example": "@custom-selector :--heading h1, h2, h3, h4, h5, h6;\n\narticle :--heading + p {}",
-    "polyfills": [
-      {
-        "type": "PostCSS Plugin",
-        "link": "https://github.com/postcss/postcss-custom-selectors"
-      }
-    ]
-  },
-  {
-    "title": "Element Queries",
-    "description": "A syntax for container-style element queries",
-    "specification": "https://tomhodgins.github.io/element-queries-spec/element-queries.html",
-    "specificationId": "elementqueries",
-    "stage": 0,
-    "example": "@element html and (min-width: 500px) {\n  body {\n    background: lime;\n  }\n}",
-    "polyfills": [
-      {
-        "type": "JavaScript Library",
-        "link": "https://github.com/eqcss/eqcss"
-      }
-    ]
-  },
-  {
-    "title": "Font `font-variant` Property",
-    "description": "A property defining the usage of alternate glyphs in a font",
-    "specification": "https://www.w3.org/TR/css-fonts-3/#propdef-font-variant",
-    "specificationId": "css-fonts-propdef-font-variant",
-    "stage": 4,
-    "caniuse": "font-variant-alternates",
-    "example": "h2 {\n  font-variant-caps: small-caps;\n}",
-    "polyfills": [
-      {
-        "type": "PostCSS Plugin",
-        "link": "https://github.com/postcss/postcss-font-variant"
-      }
-    ]
-  },
-  {
-    "title": "Font `system-ui` Family",
-    "description": "A generic font intended to match the default user interface",
-    "specification": "https://www.w3.org/TR/css-fonts-4/#system-ui-def",
-    "specificationId": "css-fonts-system-ui-def",
-    "stage": 3,
-    "caniuse": "font-family-system-ui",
-    "example": "body {\n  font-family: system-ui;\n}",
-    "polyfills": [
-      {
-        "type": "PostCSS Plugin",
-        "link": "https://github.com/JLHwung/postcss-font-family-system-ui"
-      }
-    ]
-  },
-  {
-    "title": "Grid Layout",
-    "description": "A syntax for using a grid concept to lay out content",
-    "specification": "https://www.w3.org/TR/css-grid-1/",
-    "specificationId": "css-grid",
-    "stage": 4,
-    "caniuse": "css-grid",
-    "example": "section {\n  display: grid;\n  grid-template-columns: 100px 100px 100px;\n  grid-gap: 10px;\n}",
-    "polyfills": [
-      {
-        "type": "PostCSS Plugin",
-        "link": "https://github.com/postcss/autoprefixer"
-      }
-    ]
-  },
-  {
-    "title": "Image `image-set()` Function",
-    "description": "A function for delivering the most appropriate image for a user’s device",
-    "specification": "https://www.w3.org/TR/css-images-4/#image-set-notation",
-    "specificationId": "css-images-image-set-notation",
-    "stage": 3,
-    "caniuse": "css-image-set",
-    "example": "p {\n  background-image: image-set(\n    \"foo.png\" 1x,\n    \"foo-2x.png\" 2x,\n    \"foo-print.png\" 600dpi\n  );\n}",
-    "polyfills": [
-      {
-        "type": "PostCSS Plugin",
-        "link": "https://github.com/SuperOl3g/postcss-image-set-polyfill"
-      }
-    ]
-  },
-  {
-    "title": "Logical Properties and Values",
-    "description": "Flow-relative (LTR or RTL) properties and values",
-    "specification": "https://www.w3.org/TR/css-logical/",
-    "specificationId": "css-logical",
-    "stage": 3,
-    "caniuse": "css-logical-props",
-    "example": "span:first-child {\n  float: inline-start;\n  margin-inline-start: 10px;\n}",
-    "polyfills": [
-      {
-        "type": "PostCSS Plugin",
-        "link": "https://github.com/jonathantneal/postcss-logical-properties"
-      }
-    ]
-  },
-  {
-    "title": "Media Queries Custom Media Queries",
-    "description": "An at-rule defining aliases representing media queries",
-    "specification": "https://drafts.csswg.org/mediaqueries-5/#custom-mq",
-    "specificationId": "mediaqueries-custom-mq",
-    "stage": 2,
-    "example": "@custom-media --narrow-window (max-width: 30em);\n\n@media (--narrow-window) {}",
-    "polyfills": [
-      {
-        "type": "PostCSS Plugin",
-        "link": "https://github.com/postcss/postcss-custom-media"
-      }
-    ]
-  },
-  {
-    "title": "Media Queries Ranges",
-    "description": "A syntax defining media query ranges using ordinary mathematical comparison operators",
-    "specification": "https://www.w3.org/TR/mediaqueries-4/#mq-ranges",
-    "specificationId": "mediaqueries-mq-ranges",
-    "stage": 3,
-    "example": "@media (width < 480px) {}\n\n@media (480px <= width < 768px) {}\n\n@media (width >= 768px) {}",
-    "polyfills": [
-      {
-        "type": "PostCSS Plugin",
-        "link": "https://github.com/postcss/postcss-media-minmax"
-      }
-    ]
-  },
-  {
-    "title": "Media Queries `media()` Function",
-    "description": "A function matching media queries within values",
-    "specification": "https://jonathantneal.github.io/media-expressions-spec/",
-    "specificationId": "media-expressions",
-    "stage": 0,
-    "example": "p {\n  font-size: media(\n    16px,\n    (min-width:  600px) 20px,\n    (min-width: 1000px) 40px,\n    (min-width: 1400px) 60px\n  );\n}",
-    "polyfills": [
-      {
-        "type": "PostCSS Plugin",
-        "link": "https://github.com/jonathantneal/postcss-media-fn"
-      }
-    ]
-  },
-  {
-    "title": "Nesting",
-    "description": "A syntax for nesting relative rules inside another",
-    "specification": "https://tabatkins.github.io/specs/css-nesting/",
-    "specificationId": "css-nesting",
-    "stage": 1,
-    "example": "article {\n  & p {\n    color: #333;\n  }\n}",
-    "polyfills": [
-      {
-        "type": "PostCSS Plugin",
-        "link": "https://github.com/jonathantneal/postcss-nesting"
-      }
-    ]
-  },
-  {
-    "title": "Selector Attribute Case-Sensitivity",
-    "description": "An attribute selector matching attribute values case-insensitively",
-    "specification": "https://www.w3.org/TR/selectors4/#attribute-case",
-    "specificationId": "selectors-attribute-case",
-    "stage": 3,
-    "caniuse": "css-case-insensitive",
-    "example": "[frame=hsides i] {\n  border-style: solid none;\n}",
-    "polyfills": [
-      {
-        "type": "PostCSS Plugin",
-        "link": "https://github.com/Semigradsky/postcss-attribute-case-insensitive"
-      }
-    ]
-  },
-  {
-    "title": "Selector `:any-link` Pseudo-Class",
-    "description": "A pseudo-class matching anchor elements independent of whether they have been visited",
-    "specification": "https://www.w3.org/TR/selectors4/#the-any-link-pseudo",
-    "specificationId": "selectors-any-link-pseudo",
+    "id": "any-link-pseudo-class",
+    "title": "`:any-link` Hyperlink Pseudo-Class",
+    "description": "A pseudo-class for matching anchor elements independent of whether they have been visited",
+    "specification": "https://www.w3.org/TR/selectors4/#any-link-pseudo",
     "stage": 3,
     "caniuse": "css-any-link",
     "example": "nav :any-link > span {\n  background-color: yellow;\n}",
@@ -329,10 +30,134 @@
     ]
   },
   {
-    "title": "Selector `:dir` Pseudo-Class",
-    "description": "A pseudo-class matching elements based on their directionality",
-    "specification": "https://www.w3.org/TR/selectors4/#the-dir-pseudo",
-    "specificationId": "selectors-dir-pseudo",
+    "id": "aspect-ratio-property",
+    "title": "`aspect-ratio` Property",
+    "description": "A property for defining the aspect ratio of an element",
+    "specification": "https://tomhodgins.github.io/aspect-ratio-spec/aspect-ratio.html",
+    "stage": 0,
+    "example": "div {\n  aspect-ratio: 16/9;\n  width: 200px;\n}",
+    "polyfills": [
+      {
+        "type": "JavaScript Library",
+        "link": "https://github.com/tomhodgins/aspect-ratio-spec"
+      }
+    ]
+  },
+  {
+    "id": "break-properties",
+    "title": "Break Properties",
+    "description": "Properties for defining the break behavior between and within boxes",
+    "specification": "https://www.w3.org/TR/css-break-3/#breaking-controls",
+    "stage": 4,
+    "caniuse": "multicolumn",
+    "example": "a {\n  break-inside: avoid;\n  break-before: avoid-column;\n  break-after: always;\n}",
+    "polyfills": [
+      {
+        "type": "PostCSS Plugin",
+        "link": "https://github.com/shrpne/postcss-page-break"
+      }
+    ]
+  },
+  {
+    "id": "case-insensitive-attributes",
+    "title": "Case-Insensitive Attributes",
+    "description": "An attribute selector matching attribute values case-insensitively",
+    "specification": "https://www.w3.org/TR/selectors4/#attribute-case",
+    "stage": 3,
+    "caniuse": "css-case-insensitive",
+    "example": "[frame=hsides i] {\n  border-style: solid none;\n}",
+    "polyfills": [
+      {
+        "type": "PostCSS Plugin",
+        "link": "https://github.com/Semigradsky/postcss-attribute-case-insensitive"
+      }
+    ]
+  },
+  {
+    "id": "color-functional-notation",
+    "title": "Color Functional Notation",
+    "description": "A space and slash separated notation for specifying colors",
+    "specification": "https://drafts.csswg.org/css-color/#ref-for-funcdef-rgb%E2%91%A1%E2%91%A0",
+    "stage": 2,
+    "example": "em {\n  background-color: hsl(120deg 100% 25%);\n  box-shadow: 0 0 0 10px hwb(120deg 100% 25% / 80%);\n  color: rgb(0 255 0);\n}"
+  },
+  {
+    "id": "color-mod-function",
+    "title": "`color-mod()` Function",
+    "description": "A function for modifying colors",
+    "specification": "https://www.w3.org/TR/css-color-4/#funcdef-color-mod",
+    "stage": 3,
+    "example": "p {\n  color: color-mod(black alpha(50%));\n}",
+    "polyfills": [
+      {
+        "type": "PostCSS Plugin",
+        "link": "https://github.com/jonathantneal/postcss-color-mod-function"
+      }
+    ]
+  },
+  {
+    "id": "custom-media-queries",
+    "title": "Custom Media Queries",
+    "description": "An at-rule for defining aliases that represent media queries",
+    "specification": "https://drafts.csswg.org/mediaqueries-5/#at-ruledef-custom-media",
+    "stage": 2,
+    "example": "@custom-media --narrow-window (max-width: 30em);\n\n@media (--narrow-window) {}",
+    "polyfills": [
+      {
+        "type": "PostCSS Plugin",
+        "link": "https://github.com/postcss/postcss-custom-media"
+      }
+    ]
+  },
+  {
+    "id": "custom-properties",
+    "title": "Custom Properties",
+    "description": "A syntax for defining custom values accepted by all CSS properties",
+    "specification": "https://www.w3.org/TR/css-variables-1/",
+    "stage": 4,
+    "caniuse": "css-variables",
+    "example": "img {\n  --some-length: 32px;\n\n  height: var(--some-length);\n  width: var(--some-length);\n}",
+    "polyfills": [
+      {
+        "type": "PostCSS Plugin",
+        "link": "https://github.com/postcss/postcss-custom-properties"
+      }
+    ]
+  },
+  {
+    "id": "custom-property-sets",
+    "title": "Custom Property Sets",
+    "description": "A syntax for storing properties in named variables, referenceable in other style rules",
+    "specification": "https://tabatkins.github.io/specs/css-apply-rule/",
+    "stage": -1,
+    "caniuse": "css-apply-rule",
+    "example": "img {\n  --some-length-styles: {\n    height: 32px;\n    width: 32px;\n  };\n\n  @apply --some-length-styles;\n}",
+    "polyfills": [
+      {
+        "type": "PostCSS Plugin",
+        "link": "https://github.com/pascalduez/postcss-apply"
+      }
+    ]
+  },
+  {
+    "id": "custom-selectors",
+    "title": "Custom Selectors",
+    "description": "An at-rule for defining aliases that represent selectors",
+    "specification": "https://drafts.csswg.org/css-extensions/#custom-selectors",
+    "stage": 2,
+    "example": "@custom-selector :--heading h1, h2, h3, h4, h5, h6;\n\narticle :--heading + p {}",
+    "polyfills": [
+      {
+        "type": "PostCSS Plugin",
+        "link": "https://github.com/postcss/postcss-custom-selectors"
+      }
+    ]
+  },
+  {
+    "id": "dir-pseudo-class",
+    "title": "`:dir` Directionality Pseudo-Class",
+    "description": "A pseudo-class for matching elements based on their directionality",
+    "specification": "https://www.w3.org/TR/selectors4/#dir-pseudo",
     "stage": 3,
     "caniuse": "css-dir-pseudo",
     "example": ".example:dir(rtl) {\n  margin-right: 10px;\n}\n\n.example:dir(ltr) {\n  margin-left: 10px;\n}",
@@ -344,10 +169,24 @@
     ]
   },
   {
-    "title": "Selector `:focus-visible` Focus-Indicated Pseudo-Class",
-    "description": "A pseudo-class matching elements with `:focus` that would also make focus evident",
-    "specification": "https://www.w3.org/TR/selectors-4/#the-focus-visible-pseudo",
-    "specificationId": "selectors-focus-visible-pseudo",
+    "id": "element-queries",
+    "title": "Element Queries",
+    "description": "A syntax for container-style element queries",
+    "specification": "https://tomhodgins.github.io/element-queries-spec/element-queries.html",
+    "stage": 0,
+    "example": "@element html and (min-width: 500px) {\n  body {\n    background: lime;\n  }\n}",
+    "polyfills": [
+      {
+        "type": "JavaScript Library",
+        "link": "https://github.com/eqcss/eqcss"
+      }
+    ]
+  },
+  {
+    "id": "focus-visible-pseudo-class",
+    "title": "`:focus-visible` Focus-Indicated Pseudo-Class",
+    "description": "A pseudo-class for matching focused elements that indicate that focus to a user",
+    "specification": "https://www.w3.org/TR/selectors-4/#focus-visible-pseudo",
     "stage": 3,
     "caniuse": "css-focus-visible",
     "example": ":focus:not(:focus-visible) {\n  outline: 0;\n}",
@@ -363,10 +202,10 @@
     ]
   },
   {
-    "title": "Selector `:focus-within` Focus Container Pseudo-Class",
-    "description": "A pseudo-class matching elements that either themselves match `:focus` or that have descendants which match `:focus`",
-    "specification": "https://www.w3.org/TR/selectors-4/#the-focus-within-pseudo",
-    "specificationId": "selectors-focus-within-pseudo",
+    "id": "focus-within-pseudo-class",
+    "title": "`:focus-within` Focus Container Pseudo-Class",
+    "description": "A pseudo-class for matching elements that are either focused or that have focused descendants",
+    "specification": "https://www.w3.org/TR/selectors-4/#focus-within-pseudo",
     "stage": 3,
     "caniuse": "css-focus-within",
     "example": "form:focus-within {\n  background: rgba(0, 0, 0, 0.3);\n}",
@@ -382,10 +221,137 @@
     ]
   },
   {
-    "title": "Selector `:matches()` Matches-Any Pseudo-Class",
-    "description": "A pseudo-class matching elements in a selector list",
-    "specification": "https://www.w3.org/TR/selectors4/#matches",
-    "specificationId": "selectors-matches-pseudo",
+    "id": "font-variant-property",
+    "title": "`font-variant` Property",
+    "description": "A property for defining the usage of alternate glyphs in a font",
+    "specification": "https://www.w3.org/TR/css-fonts-3/#propdef-font-variant",
+    "stage": 4,
+    "caniuse": "font-variant-alternates",
+    "example": "h2 {\n  font-variant-caps: small-caps;\n}",
+    "polyfills": [
+      {
+        "type": "PostCSS Plugin",
+        "link": "https://github.com/postcss/postcss-font-variant"
+      }
+    ]
+  },
+  {
+    "id": "gray-function",
+    "title": "`gray()` Function",
+    "description": "A function for specifying fully desaturated colors",
+    "specification": "https://www.w3.org/TR/css-color-4/#funcdef-gray",
+    "stage": 3,
+    "example": "p {\n  color: gray(50);\n}",
+    "polyfills": [
+      {
+        "type": "PostCSS Plugin",
+        "link": "https://github.com/postcss/postcss-color-gray"
+      }
+    ]
+  },
+  {
+    "id": "grid-layout",
+    "title": "Grid Layout",
+    "description": "A syntax for using a grid concept to lay out content",
+    "specification": "https://www.w3.org/TR/css-grid-1/",
+    "stage": 4,
+    "caniuse": "css-grid",
+    "example": "section {\n  display: grid;\n  grid-template-columns: 100px 100px 100px;\n  grid-gap: 10px;\n}",
+    "polyfills": [
+      {
+        "type": "PostCSS Plugin",
+        "link": "https://github.com/postcss/autoprefixer"
+      }
+    ]
+  },
+  {
+    "id": "has-pseudo-class",
+    "title": "`:has()` Relational Pseudo-Class",
+    "description": "A pseudo-class for matching ancestor and sibling elements",
+    "specification": "https://www.w3.org/TR/selectors-4/#has-pseudo",
+    "stage": 3,
+    "example": "a:has(> img) {\n  display: block;\n}"
+  },
+  {
+    "id": "hexadecimal-alpha-notation",
+    "title": "Hexadecimal Alpha Notation",
+    "description": "A 4 & 8 character hex color notation for specifying the opacity level",
+    "specification": "https://www.w3.org/TR/css-color-4/#hex-notation",
+    "stage": 3,
+    "caniuse": "css-rrggbbaa",
+    "example": "section {\n  background-color: #f3f3f3f3;\n  color: #0003;\n}",
+    "polyfills": [
+      {
+        "type": "PostCSS Plugin",
+        "link": "https://github.com/postcss/postcss-color-hex-alpha"
+      }
+    ]
+  },
+  {
+    "id": "hwb-function",
+    "title": "`hwb()` Function",
+    "description": "A function for specifying colors by hue and then a degree of whiteness and blackness to mix into it",
+    "specification": "https://www.w3.org/TR/css-color-4/#funcdef-hwb",
+    "stage": 3,
+    "example": "p {\n  color: hwb(120 44% 50%);\n}",
+    "polyfills": [
+      {
+        "type": "PostCSS Plugin",
+        "link": "https://github.com/postcss/postcss-color-hwb"
+      }
+    ]
+  },
+  {
+    "id": "image-set-function",
+    "title": "`image-set()` Function",
+    "description": "A function for specifying image sources based on the user’s resolution",
+    "specification": "https://www.w3.org/TR/css-images-4/#image-set-notation",
+    "stage": 3,
+    "caniuse": "css-image-set",
+    "example": "p {\n  background-image: image-set(\n    \"foo.png\" 1x,\n    \"foo-2x.png\" 2x,\n    \"foo-print.png\" 600dpi\n  );\n}",
+    "polyfills": [
+      {
+        "type": "PostCSS Plugin",
+        "link": "https://github.com/jonathantneal/postcss-image-set-function"
+      }
+    ]
+  },
+  {
+    "id": "lab-function",
+    "title": "`lab()` Function",
+    "description": "A function for specifying colors expressed in the CIE Lab color space",
+    "specification": "https://www.w3.org/TR/css-color-4/#funcdef-lab",
+    "stage": 3,
+    "example": "example {\n  color: lab(240 50 20)\n}"
+  },
+  {
+    "id": "lch-function",
+    "title": "`lch()` Function",
+    "description": "A function for specifying colors expressed in the CIE Lab color space with chroma and hue",
+    "specification": "https://www.w3.org/TR/css-color-4/#funcdef-lch",
+    "stage": 3,
+    "example": "example {\n  color: lch(53 105 40)\n}"
+  },
+  {
+    "id": "logical-properties-and-values",
+    "title": "Logical Properties and Values",
+    "description": "Flow-relative (left-to-right or right-to-left) properties and values",
+    "specification": "https://www.w3.org/TR/css-logical/",
+    "stage": 3,
+    "caniuse": "css-logical-props",
+    "example": "span:first-child {\n  float: inline-start;\n  margin-inline-start: 10px;\n}",
+    "polyfills": [
+      {
+        "type": "PostCSS Plugin",
+        "link": "https://github.com/jonathantneal/postcss-logical-properties"
+      }
+    ]
+  },
+  {
+    "id": "matches-pseudo-class",
+    "title": "`:matches()` Matches-Any Pseudo-Class",
+    "description": "A pseudo-class for matching elements in a selector list",
+    "specification": "https://www.w3.org/TR/selectors4/#matches-pseudo",
     "stage": 3,
     "caniuse": "css-matches-pseudo",
     "example": "p:matches(:first-child, .special) {\n  margin-top: 1em;\n}",
@@ -397,10 +363,52 @@
     ]
   },
   {
-    "title": "Selector `:not()` Selector List Negation Pseudo-Class",
-    "description": "A pseudo-class ignoring elements in a selector list",
-    "specification": "https://www.w3.org/TR/selectors4/#negation",
-    "specificationId": "selectors-negation-pseudo",
+    "id": "media-function",
+    "title": "`media()` Function",
+    "description": "A function for specifying media queries within values",
+    "specification": "https://jonathantneal.github.io/media-expressions-spec/",
+    "stage": 0,
+    "example": "p {\n  font-size: media(\n    16px,\n    (min-width:  600px) 20px,\n    (min-width: 1000px) 40px,\n    (min-width: 1400px) 60px\n  );\n}",
+    "polyfills": [
+      {
+        "type": "PostCSS Plugin",
+        "link": "https://github.com/jonathantneal/postcss-media-fn"
+      }
+    ]
+  },
+  {
+    "id": "media-query-ranges",
+    "title": "Media Query Ranges",
+    "description": "A syntax for defining media query ranges using ordinary comparison operators",
+    "specification": "https://www.w3.org/TR/mediaqueries-4/#range-context",
+    "stage": 3,
+    "example": "@media (width < 480px) {}\n\n@media (480px <= width < 768px) {}\n\n@media (width >= 768px) {}",
+    "polyfills": [
+      {
+        "type": "PostCSS Plugin",
+        "link": "https://github.com/postcss/postcss-media-minmax"
+      }
+    ]
+  },
+  {
+    "id": "nesting-rules",
+    "title": "Nesting Rules",
+    "description": "A syntax for nesting relative rules within rules",
+    "specification": "https://tabatkins.github.io/specs/css-nesting/",
+    "stage": 1,
+    "example": "article {\n  & p {\n    color: #333;\n  }\n}",
+    "polyfills": [
+      {
+        "type": "PostCSS Plugin",
+        "link": "https://github.com/jonathantneal/postcss-nesting"
+      }
+    ]
+  },
+  {
+    "id": "not-pseudo-class",
+    "title": "`:not()` Negation Pseudo-Class",
+    "description": "A pseudo-class for ignoring elements in a selector list",
+    "specification": "https://www.w3.org/TR/selectors4/#negation-pseudo",
     "stage": 3,
     "caniuse": "css-not-sel-list",
     "example": "p:not(:first-child, .special) {\n  margin-top: 1em;\n}",
@@ -412,24 +420,10 @@
     ]
   },
   {
-    "title": "Sizing `aspect-ratio` Property",
-    "description": "A property for defining the aspect ratio of an element",
-    "specification": "https://tomhodgins.github.io/aspect-ratio-spec/aspect-ratio.html",
-    "specificationId": "aspect-ratio",
-    "stage": 0,
-    "example": "div {\n  aspect-ratio: 16/9;\n  width: 200px;\n}",
-    "polyfills": [
-      {
-        "type": "JavaScript Library",
-        "link": "https://github.com/tomhodgins/aspect-ratio-spec"
-      }
-    ]
-  },
-  {
-    "title": "Text `overflow-wrap` Property",
+    "id": "overflow-wrap-property",
+    "title": "`overflow-wrap` Property",
     "description": "A property for defining whether to insert line breaks within words to prevent overflowing",
     "specification": "https://www.w3.org/TR/css-text-3/#overflow-wrap-property",
-    "specificationId": "css-text-overflow-wrap-property",
     "stage": 3,
     "caniuse": "wordwrap",
     "example": "p {\n  overflow-wrap: break-word;\n}",
@@ -441,10 +435,48 @@
     ]
   },
   {
+    "id": "rebeccapurple-color",
+    "title": "`rebeccapurple` Color",
+    "description": "A particularly lovely shade of purple in memory of Rebecca Alison Meyer",
+    "specification": "https://www.w3.org/TR/css-color-4/#valdef-color-rebeccapurple",
+    "stage": 3,
+    "caniuse": "css-rebeccapurple",
+    "example": "html {\n  color: rebeccapurple;\n}",
+    "polyfills": [
+      {
+        "type": "PostCSS Plugin",
+        "link": "https://github.com/postcss/postcss-color-rebeccapurple"
+      }
+    ]
+  },
+  {
+    "id": "something-pseudo-class",
+    "title": "`:something()` Zero-Specificity Pseudo-Class",
+    "description": "A pseudo-class for matching elements in a selector list without contributing specificity",
+    "specification": "https://www.w3.org/TR/selectors-4/#something-pseudo",
+    "stage": 3,
+    "example": "a:something(:not(:hover)) {\n  text-decoration: none;\n}"
+  },
+  {
+    "id": "system-ui-font-family",
+    "title": "`system-ui` Font Family",
+    "description": "A generic font used to match the user’s interface",
+    "specification": "https://www.w3.org/TR/css-fonts-4/#system-ui-def",
+    "stage": 3,
+    "caniuse": "font-family-system-ui",
+    "example": "body {\n  font-family: system-ui;\n}",
+    "polyfills": [
+      {
+        "type": "PostCSS Plugin",
+        "link": "https://github.com/JLHwung/postcss-font-family-system-ui"
+      }
+    ]
+  },
+  {
+    "id": "when-else-rules",
     "title": "When/Else Rules",
-    "description": "At-rules defining conditional rules and unifying the disparate conditional rules into a single grammar",
+    "description": "At-rules for specifying media queries and support queries in a single grammar",
     "specification": "https://tabatkins.github.io/specs/css-when-else/",
-    "specificationId": "css-when-else",
     "stage": 1,
     "example": "@when media(width >= 640px) and (supports(display: flex) or supports(display: grid)) {\n  /* A */\n} @else media(pointer: coarse) {\n  /* B */\n} @else {\n  /* C */\n}"
   }

--- a/package.json
+++ b/package.json
@@ -4,9 +4,9 @@
   "description": "A comprehensive list of CSS features and their positions in the process of becoming implemented web standards",
   "author": "Jonathan Neal <jonathantneal@hotmail.com>",
   "license": "CC0-1.0",
-  "repository": "jonathantneal/css-db",
-  "homepage": "https://github.com/jonathantneal/css-db#readme",
-  "bugs": "https://github.com/jonathantneal/css-db/issues",
+  "repository": "jonathantneal/cssdb",
+  "homepage": "https://github.com/jonathantneal/cssdb#readme",
+  "bugs": "https://github.com/jonathantneal/cssdb/issues",
   "main": "cssdb.json",
   "files": [
     "cssdb.json"
@@ -16,13 +16,13 @@
     "test": "node tasks/test"
   },
   "devDependencies": {
-    "browserslist": "^3.2.0",
-    "caniuse-lite": "^1.0.30000815",
+    "browserslist": "^3.2.4",
+    "caniuse-lite": "^1.0.30000824",
     "eslit": "^5.0.0",
     "fse": "^4.0.0",
-    "marked": "^0.3.17",
-    "node-fetch": "^2.1.1",
-    "postcss": "^6.0.20",
+    "marked": "^0.3.19",
+    "node-fetch": "^2.1.2",
+    "postcss": "^6.0.21",
     "pre-commit": "^1.2.2"
   },
   "keywords": [

--- a/tasks/start-template.html
+++ b/tasks/start-template.html
@@ -7,10 +7,10 @@
 <meta name="twitter:site" content="@jon_neal">
 <meta name="twitter:title" content="CSS Database">
 <meta name="twitter:description" content="A comprehensive list of CSS features and their positions in the process of becoming implemented web standards.">
-<meta name="twitter:image" content="https://jonathantneal.github.io/css-db/cssdb.jpg">
-<meta property="og:image" content="https://jonathantneal.github.io/css-db/cssdb.jpg" itemprop="thumbnailUrl">
+<meta name="twitter:image" content="https://jonathantneal.github.io/cssdb/cssdb.jpg">
+<meta property="og:image" content="https://jonathantneal.github.io/cssdb/cssdb.jpg" itemprop="thumbnailUrl">
 <meta property="og:title" content="CSS Database">
-<meta property="og:url" content="https://jonathantneal.github.io/css-db">
+<meta property="og:url" content="https://jonathantneal.github.io/cssdb">
 <meta property="og:site_name" content="GitHub">
 <meta property="og:description" content="A comprehensive list of CSS features and their positions in the process of becoming implemented web standards.">
 <link href="cssdb.ico" rel="shortcut icon">
@@ -30,12 +30,12 @@
 </header>
 
 <main class="cssdb-features" id="features">
-	${features.map(feature => `<section class="cssdb-feature" id="${feature.specificationId}">
+	${features.map(feature => `<section class="cssdb-feature" id="${feature.id}">
 		<header class="cssdb-feature-header">
 			<img class="cssdb-feature-stage" src="stage-${ feature.stage === -1 ? 'X' : feature.stage }.svg" alt="" width="62" height="62">
 			<div class="cssdb-feature-header-content">
 				<h3 class="cssdb-feature-heading">
-					<a href="#${feature.specificationId}">${feature.title}</a>
+					<a href="#${feature.id}">${feature.title}</a>
 				</h3>
 				<p class="cssdb-feature-description">
 					${feature.description}
@@ -45,8 +45,8 @@
 		<div class="cssdb-feature-content">
 			<p class="cssdb-feature-specification">
 				<a class="cssdb-feature-specification-link" href="${feature.specification}">Specification</a>
-				<a class="cssdb-feature-specification-badge-link" href="badge/${feature.specificationId}.svg" tabindex="-1">
-					<img class="cssdb-feature-specification-badge" src="badge/${feature.specificationId}.svg" alt="cssdb badge">
+				<a class="cssdb-feature-specification-badge-link" href="badge/${feature.id}.svg" tabindex="-1">
+					<img class="cssdb-feature-specification-badge" src="badge/${feature.id}.svg" alt="cssdb badge">
 				</a>
 			</p>
 			<pre class="cssdb-feature-example">${feature.example}</pre>
@@ -85,7 +85,7 @@
 
 <p>
 	Want to contribute? Checkout the
-	<a href="https://github.com/jonathantneal/css-db">cssdb on GitHub</a>
+	<a href="https://github.com/jonathantneal/cssdb">cssdb on GitHub</a>
 </p>
 
 <script>

--- a/tasks/test.js
+++ b/tasks/test.js
@@ -9,60 +9,112 @@ const failSymbol = '\x1b[31m✖\x1b[0m';
 // path to cssdb.json
 const cssdbJSON = path.join(__dirname, '../cssdb.json');
 
+// whether to fix the file if possible
+const isToBeFixed = process.argv.indexOf('--fix') !== -1;
+
 // test features.json
 fs.readJson(cssdbJSON).then(allHaveRequiredData).then(
-	(length) => console.log(`${passSymbol} all ${length} features are valid.`),
-	(error)  => console.log(`${failSymbol} some feature did not validate.\n  → ${error}`)
+	length => console.log(`${passSymbol} all ${length} features are valid.`),
+	error  => console.log(`${failSymbol} something did not validate.\n  → ${error}`)
 );
 
 // test all features for validity
 function allHaveRequiredData(features) {
-	const hasOrderlyFeatures = getFeatureTitles(features).join() === getFeatureTitles(features).sort().join();
+	if (isToBeFixed) {
+		fixFeaturesOrdering(features);
+	}
+
+	const hasOrderlyFeatures = getFeatureIds(features).join() === getFeatureIds(features).sort().join();
 
 	if (!hasOrderlyFeatures) {
-		throw ValidationError('UNORDERLY FEATURES', 'Expected order', JSON.stringify(getFeatureTitles(features).sort(), null, '    ').slice(1, -2));
+		throw validationError('UNORDERLY FEATURES', 'Received order', JSON.stringify(getFeatureIds(features), null, '    ').slice(1, -2));
 	}
 
 	features.forEach(hasRequiredData);
 
-	return features.length;
+	return fs.writeFile(
+		cssdbJSON,
+		`${JSON.stringify(features, null, '  ')}\n`
+	).then(
+		() => features.length
+	);
 }
 
 // test a feature for validity
 function hasRequiredData(feature) {
 	const title = Object(feature).title || 'Unknown Feature';
 	const keys = Object.keys(Object(feature));
+	const ordering = ['id', 'title', 'description', 'specification', 'stage'];
+	const polyfillOrdering = ['type', 'link'];
 
-	const hasRequiredFields = keys.slice(0, 5).join() === 'title,description,specification,specificationId,stage';
+	const hasRequiredFields = keys.slice(0, 5).join() === ordering.join();
 	const hasValidStage = feature.stage === -1 || feature.stage === 0 || feature.stage === 1 || feature.stage === 2 || feature.stage === 3 || feature.stage === 4 || feature.stage === 5;
 	const hasOrderlyAdditionalFields = keys.slice(5).join() === keys.slice(5).sort().join();
 	const hasOrderlyPolyfills = !Array.isArray(feature.polyfills) || feature.polyfills.every(
-		(polyfill) => Object.keys(Object(polyfill)).join() === 'type,link'
+		polyfill => Object.keys(Object(polyfill)).join() === polyfillOrdering.join()
 	);
 
-	if (!hasRequiredFields) {
-		throw ValidationError('MISSING OR UNORDERLY REQUIRED FIELDS', title, keys.slice(0, 5).join(', '));
+	if (isToBeFixed) {
+		if (!hasRequiredFields || !hasOrderlyAdditionalFields) {
+			fixFeatureOrdering(feature, ordering);
+		}
+
+		if (!hasOrderlyPolyfills) {
+			fixFeatureOrdering(feature.polyfills, polyfillOrdering);
+		}
+	} else if (!hasRequiredFields) {
+		throw validationError('MISSING OR UNORDERLY REQUIRED FIELDS', title, keys.slice(0, 5).join(', '));
+	} else if (!hasOrderlyAdditionalFields) {
+		throw validationError('UNORDERLY ADDITIONAL FIELDS', title, keys.slice(5).join(', '));
+	} else if (!hasOrderlyPolyfills) {
+		validationError('UNORDERLY POLYFILLS FIELDS', title, polyfillOrdering.join(', '))
 	}
 
 	if (!hasValidStage) {
-		throw ValidationError('INVALID STAGE', title, feature.stage);
-	}
-
-	if (!hasOrderlyAdditionalFields) {
-		throw ValidationError('UNORDERLY ADDITIONAL FIELDS', title, keys.slice(5).join(', '));
-	}
-
-	if (!hasOrderlyPolyfills) {
-		throw ValidationError('UNORDERLY POLYFILLS FIELDS', title, 'type, link');
+		throw validationError('INVALID STAGE', title, feature.stage);
 	}
 }
 
 // report a validation error
-function ValidationError(issue, title, notice) {
+function validationError(issue, title, notice) {
 	return `${issue}: ${title}${notice ? ` (${notice})` : ''}`
 }
 
-// get feature titles
-function getFeatureTitles(features) {
-	return features.slice(0).map((feature) => feature.title);
+// get feature ids
+function getFeatureIds(features) {
+	return features.slice(0).map(feature => feature.id);
+}
+
+// fixes all feature ordering
+function fixFeaturesOrdering(features) {
+	const sorting = ({ id: a }, { id: b }) => a < b ? -1 : a > b ? 1 : 0;
+
+	features.sort(sorting);
+}
+
+
+// fixes a feature ordering
+function fixFeatureOrdering(object, order, error) {
+	const clone = {};
+	const hasEveryKey = order.every(key => key in object);
+	const keys = Object.keys(object);
+	const additionalKeys = keys.filter(key => order.indexOf(key) === -1).sort();
+
+	if (hasEveryKey) {
+		keys.forEach(
+			key => {
+				clone[key] = object[key];
+
+				delete object[key];
+			}
+		)
+
+		order.concat(additionalKeys).forEach(
+			key => {
+				object[key] = clone[key];
+			}
+		);
+	} else {
+		throw error;
+	}
 }


### PR DESCRIPTION
- Renamed: GitHub repository from `css-db` to `cssdb`, now aligning with npm.
- Renamed: All feature IDs.
- Updated: Documentation.

Notes: The old feature IDs were problematic because they attempted to follow specification section IDs, but some specifications weren’t aren’t always covered by a single section, and many sections were inconsistently named. Because there was no pattern one could predict for any of the headings, a new system was created for cssdb; to **name** the feature and provide **context**. This meant a feature ID like `css-cascade-all-shorthand` became `all-property`, and `css-fonts-propdef-font-variant` became `font-variant-property`, etc. This greatly simplified all of the feature IDs and allowed for more predictive naming moving forward.

Resolves #18